### PR TITLE
fix: remove unused imports, add `type` keyword when importing `Context`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
-import { Elysia, Handler, Context } from 'elysia'
-
-import { isAbsolute } from 'path'
+import Elysia, { type Context } from 'elysia'
 
 type Origin = string | RegExp | ((request: Request) => boolean | void)
 


### PR DESCRIPTION
Hi, when using TypeScript with `verbatimModuleSyntax: true`, sometimes we got this error which prevents the project from compiling:

![image](https://github.com/elysiajs/elysia-cors/assets/3425302/c4398efe-2e40-4120-952a-39fe73222b78)

This PR fixes the problem by adding an explicit "type" in the import for `Context`. I also removed `Handler` and `isAbsolute` as it is not used anywhere in the file. Thank you