### PR TITLE
Correctly set Access-Control-Expose-Headers field and do not call prelfight handlers twice

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,32 +244,14 @@ export const cors = (
     }
 
     if (preflight)
-        app.options('/', ({ set, request }) => {
-            handleOrigin(set as any, request)
-            handleMethod(set)
-
-            if (exposedHeaders.length)
-                set.headers['Access-Control-Allow-Headers'] =
-                    typeof allowedHeaders === 'string'
-                        ? allowedHeaders
-                        : allowedHeaders.join(', ')
-
+        app.options('/', ({ set }) => {
             if (maxAge)
                 set.headers['Access-Control-Max-Age'] = maxAge.toString()
 
             return new Response('', {
                 status: 204
             })
-        }).options('/*', ({ set, request }) => {
-            handleOrigin(set as any, request)
-            handleMethod(set)
-
-            if (exposedHeaders.length)
-                set.headers['Access-Control-Allow-Headers'] =
-                    typeof allowedHeaders === 'string'
-                        ? allowedHeaders
-                        : allowedHeaders.join(', ')
-
+        }).options('/*', ({ set }) => {
             if (maxAge)
                 set.headers['Access-Control-Max-Age'] = maxAge.toString()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ interface CORSConfig {
     /**
      * @default `*`
      *
-     * Assign **Access-Control-Exposed-Headers** header.
+     * Assign **Access-Control-Expose-Headers** header.
      *
      * Return the specified headers to request in CORS mode.
      *
@@ -289,7 +289,7 @@ export const cors = (
                     : allowedHeaders.join(', ')
 
         if (exposedHeaders.length)
-            set.headers['Access-Control-Exposed-Headers'] =
+            set.headers['Access-Control-Expose-Headers'] =
                 typeof exposedHeaders === 'string'
                     ? exposedHeaders
                     : exposedHeaders.join(', ')

--- a/test/allow-headers.test.ts
+++ b/test/allow-headers.test.ts
@@ -2,7 +2,7 @@ import { Elysia } from 'elysia'
 import { cors } from '../src'
 
 import { describe, expect, it } from 'bun:test'
-import { req } from './utils'
+import { preflight, req } from './utils'
 
 describe('Allowed Headers', () => {
     it('Accept single header', async () => {
@@ -30,6 +30,38 @@ describe('Allowed Headers', () => {
             .get('/', () => 'HI')
 
         const res = await app.handle(req('/'))
+        expect(res.headers.get('Access-Control-Allow-Headers')).toBe(
+            'Content-Type, X-Imaginary-Value'
+        )
+    })
+
+    it('Accept array preflight', async () => {
+        const app = new Elysia()
+            .use(
+                cors({
+                    allowedHeaders: ['Content-Type', 'X-Imaginary-Value']
+                })
+            )
+            .get('/', () => 'HI')
+
+        const res = await app.handle(preflight('/'))
+        expect(res.headers.get('Access-Control-Allow-Headers')).toBe(
+            'Content-Type, X-Imaginary-Value'
+        )
+    })
+
+    it('Accept array preflight with exposed headers plain string', async () => {
+        const app = new Elysia()
+            .use(
+                cors({
+                    allowedHeaders: ['Content-Type', 'X-Imaginary-Value'],
+                    //Exposed headers empty value
+                    exposedHeaders: ''
+                })
+            )
+            .get('/', () => 'HI')
+
+        const res = await app.handle(preflight('/'))
         expect(res.headers.get('Access-Control-Allow-Headers')).toBe(
             'Content-Type, X-Imaginary-Value'
         )

--- a/test/exposed-header.test.ts
+++ b/test/exposed-header.test.ts
@@ -15,7 +15,7 @@ describe('Exposed Headers', () => {
             .get('/', () => 'HI')
 
         const res = await app.handle(req('/'))
-        expect(res.headers.get('Access-Control-Exposed-Headers')).toBe(
+        expect(res.headers.get('Access-Control-Expose-Headers')).toBe(
             'Content-Type'
         )
     })
@@ -30,7 +30,7 @@ describe('Exposed Headers', () => {
             .get('/', () => 'HI')
 
         const res = await app.handle(req('/'))
-        expect(res.headers.get('Access-Control-Exposed-Headers')).toBe(
+        expect(res.headers.get('Access-Control-Expose-Headers')).toBe(
             'Content-Type, X-Imaginary-Value'
         )
     })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,7 +12,7 @@ describe('CORS', () => {
         expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
         expect(res.headers.get('Access-Control-Allow-Methods')).toBe('*')
         expect(res.headers.get('Access-Control-Allow-Headers')).toBe('*')
-        expect(res.headers.get('Access-Control-Exposed-Headers')).toBe('*')
+        expect(res.headers.get('Access-Control-Expose-Headers')).toBe('*')
         expect(res.headers.get('Access-Control-Allow-Credentials')).toBe(null)
     })
 })


### PR DESCRIPTION
Identical to #34, use a different branch so additional fixes can be pushed to master. 

Fix issue: #33 

The usage of the `exposedHeaders.length` instead of the `allowedHeaders.length` didn't surface because the `app.onRequest` handler is also run for preflights which has overwritten all headers set inside the preflight handler anyways.