### PR TITLE
chore: Update package types

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "import": "./dist/index.js",
     "default": "./dist/cjs/index.js"
   },
-  "types": "./src/index.ts",
+  "types": "./dist/index.d.ts",
   "homepage": "https://github.com/elysiajs/elysia-cors",
   "keywords": [
     "elysia",


### PR DESCRIPTION
`package.json` currently uses the source `.ts` file for its types, and the built `.js` files for code imports. The issue I was running into is that due to `.ts` file being used for types, it was being included and when `tsc` is used for type checking, it would report issues within eg. `node_modules/@elysiajs/cors/src/index.ts` (screenshot down below).

This behavior is to be expected per various threads, and is due to source files being imported instead of the `.d.ts` files which can be skipped using the `skipLibCheck` flag. As far as I can tell, both `.js` and `.d.ts` are already built and available, so there is likely no downside in using `.d.ts` for type definitions, and it should avoid the issue where types are treated as source code for the importer

<img width="709" alt="Screenshot 2024-06-14 at 11 05 28" src="https://github.com/elysiajs/elysia-cors/assets/3406718/f68a8b86-cb95-4e32-9695-65d23fb7366e">
