### PR TITLE
fix: remove useless options hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -331,7 +331,7 @@ export const cors = (config?: CORSConfig) => {
 		})
 	}
 
-	if (preflight) app.options('/', handleOption).options('/*', handleOption)
+	if (preflight) app.options('/*', handleOption)
 
 	return app.onRequest(function processCors({ set, request }) {
 		handleOrigin(set, request)


### PR DESCRIPTION
Remove `/` from option hook (`/` is included in `/*`).