### PR TITLE
Allow allowedHeaders and exposeHeaders to receive false

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,8 +113,10 @@ interface CORSConfig {
 	 *
 	 * - `string[]` - Allow multiple HTTP methods.
 	 *     - eg: ['Content-Type', 'Authorization']
+         *
+	 * - `false` - Do not send `Access-Control-Allow-Headers` header.
 	 */
-	allowedHeaders?: true | string | string[]
+	allowedHeaders?: boolean | string | string[]
 	/**
 	 * @default `*`
 	 *
@@ -128,8 +130,10 @@ interface CORSConfig {
 	 *
 	 * - `string[]` - Allow multiple HTTP methods.
 	 *     - eg: ['Content-Type', 'X-Powered-By']
+         *
+	 * - `false` - Do not send `Access-Control-Expose-Headers` header.
 	 */
-	exposeHeaders?: true | string | string[]
+	exposeHeaders?: boolean | string | string[]
 	/**
 	 * @default `true`
 	 *


### PR DESCRIPTION
Currently, the plugin sends a set of default headers for `Access-Control-Allowed-Headers` and `Access-Control-Expose-Headers`:

![image](https://github.com/user-attachments/assets/aae3d878-406e-42e2-99fe-7009604d936d)

We can actually set `allowedHeaders` and `exposeHeaders` to `false` to avoid sending the headers:

```ts
const app = new Elysia()
  .use(cors({
    allowedHeaders: false as any,
    exposeHeaders: false as any,
  }))
```

![image](https://github.com/user-attachments/assets/e5d5cfe4-9ecd-471f-9543-7c36ccc42d62)

This PR updates the types so `false` is accepted as value for the options.