### PR TITLE
refactor(handleOrigin): simplify the function by removing some unused codes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -266,24 +266,18 @@ export const cors = (config?: CORSConfig) => {
 
 		if (!origins?.length) return
 
-		const headers: string[] = []
+		const from = request.headers.get('Origin') ?? ''
+		for (let i = 0; i < origins.length; i++) {
+			const value = processOrigin(origins[i]!, request, from)
+			if (value) {
+				set.headers.vary = origin ? 'Origin' : '*'
+				set.headers['access-control-allow-origin'] = from || '*'
 
-		if (origins.length) {
-			const from = request.headers.get('Origin') ?? ''
-			for (let i = 0; i < origins.length; i++) {
-				const value = processOrigin(origins[i]!, request, from)
-				if (value === true) {
-					set.headers.vary = origin ? 'Origin' : '*'
-					set.headers['access-control-allow-origin'] = from || '*'
-
-					return
-				}
+				return
 			}
 		}
 
 		set.headers.vary = 'Origin'
-		if (headers.length)
-			set.headers['access-control-allow-origin'] = headers.join(', ')
 	}
 
 	const handleMethod = (set: Context['set'], method?: string | null) => {


### PR DESCRIPTION
1. Removed `headers` array: it was always empty and never modified, so the `if (headers.length)` check was dead code and `headers` itself was unused.

2. Removed redundant `if (origins.length)` check: the function already returns early when `origins` is falsy (`if (!origins?.length) return`).